### PR TITLE
Add source hash to S3 objects metadata in codebuild-artifacts.sh

### DIFF
--- a/scripts/codebuild-artifacts.sh
+++ b/scripts/codebuild-artifacts.sh
@@ -13,7 +13,7 @@ function upload_to_s3 {
 
   sourceHash=$(openssl dgst -binary -sha256 "$sourceFilename" | openssl base64)
   aws s3 cp "$sourceFilename" \
-    "s3://$S3_BUCKET/reporting/$destinationFilename" \
+    "s3://$ARTIFACT_BUCKET/reporting/$destinationFilename" \
     --content-type "$contentType" \
     --acl bucket-owner-full-control \
     --metadata hash="$sourceHash"

--- a/scripts/codebuild-artifacts.sh
+++ b/scripts/codebuild-artifacts.sh
@@ -11,10 +11,12 @@ function upload_to_s3 {
     contentType="application/octet-stream"
   fi
 
+  sourceHash=$(openssl dgst -binary -sha256 "$sourceFilename" | openssl base64)
   aws s3 cp "$sourceFilename" \
     "s3://$S3_BUCKET/reporting/$destinationFilename" \
     --content-type "$contentType" \
-    --acl bucket-owner-full-control
+    --acl bucket-owner-full-control \
+    --metadata hash="$sourceHash"
 }
 
 ############################################


### PR DESCRIPTION
Updated `codebuild-artifacts.sh` script to hash the source file and add it to the S3 object metadata.
This hash in metadata will be used in terraform to check if the lambda function needs redeployment.