### PR TITLE
Fixed failing test in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - checkout
       - restore_all_caches
+      - run: nvm install
       - run: npm install
       - save_all_caches
       - run: npm run build

--- a/src/common-platform-report/index.e2e.test.ts
+++ b/src/common-platform-report/index.e2e.test.ts
@@ -1,4 +1,5 @@
 jest.setTimeout(30000)
+process.env.API_URL = "http://localhost:23851"
 process.env.AWS_URL = "http://localhost:20001"
 process.env.AWS_REGION = "local"
 process.env.DYNAMO_AWS_ACCESS_KEY_ID = "test"
@@ -23,7 +24,7 @@ describe("End to end testing the lambda", () => {
   let apiGatewayServer: MockServer
 
   beforeAll(async () => {
-    apiGatewayServer = new MockServer({ port: 20001 })
+    apiGatewayServer = new MockServer({ port: 23851 })
     await apiGatewayServer.start()
     mailServer = new MockMailServer(20002)
   })


### PR DESCRIPTION
Circle CI had been failing for a couple weeks, it is possible that since we have updated to the latests ubuntu image the port we were using to mock out sending an email is now being occupied by a that image. We have now used a random port for the mock