### PR TITLE
BICAWS7-3592 - Fix csv-parse type

### DIFF
--- a/src/shared/csv-to-xlsx/index.ts
+++ b/src/shared/csv-to-xlsx/index.ts
@@ -3,7 +3,7 @@ import type { KeyValuePair } from "src/shared/types"
 import xlsx from "xlsx-js-style"
 
 const csvOptions = {
-  columns: true,
+  columns: true as const,
   delimiter: ",",
   ltrim: true,
   rtrim: true
@@ -54,8 +54,7 @@ const calculateColumnWidths = (records: KeyValuePair<string, string>[]): { width
 }
 
 const convertCsvToXlsx = (csvData: string, title?: string): Buffer => {
-  // @ts-expect-error: Incorrect type definition in csv-parse/sync parse function
-  const records = parse(csvData, csvOptions) as KeyValuePair<string, string>[]
+  const records = parse<KeyValuePair<string, string>>(csvData, csvOptions)
   const wb = xlsx.utils.book_new()
   let jsonRows = []
   if (title) {


### PR DESCRIPTION
The parse function had an overload which took a generic and used it in the return type, avoiding the need for a type cast. I also had to set the `columns` property on the `csvOptions` object to a constant as using the generic version of parse only allowed this to be true (not having it as a constant caused TypeScript to only treat it as a boolean).